### PR TITLE
Add FA5 support for icons

### DIFF
--- a/assets/javascripts/discourse/components/docked-composer.js.es6
+++ b/assets/javascripts/discourse/components/docked-composer.js.es6
@@ -248,7 +248,7 @@ export default Ember.Component.extend({
 
   @computed('composeState')
   togglerIcon(composeState) {
-    return composeState === 'minimized' ? 'fa-angle-up' : 'fa-angle-down';
+    return composeState === 'minimized' ? 'angle-up' : 'angle-down';
   },
 
   scrollPoststream() {

--- a/assets/javascripts/discourse/components/docked-editor.js.es6
+++ b/assets/javascripts/discourse/components/docked-editor.js.es6
@@ -79,10 +79,10 @@ export default DEditor.extend({
       if (this.site.mobileView && this.get('focusState') === 'focus') {
         Ember.run.next(() => {
           const $target = $(e.target);
-          if ($target.hasClass('fa-picture-o')) {
+          if ($target.hasClass('qm-upload-picture')) {
             this.$('.docked-upload input').click();
           };
-          if ($target.hasClass('fa-smile-o')) {
+          if ($target.hasClass('qm-emoji')) {
             this.sendAction('toggleEmojiPicker');
           }
         });

--- a/assets/javascripts/discourse/templates/components/docked-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/docked-composer.hbs
@@ -1,8 +1,14 @@
 <div class="docked-composer-header">
   <div class="controls">
-    <a href class='cancel fa fa-times' {{action "cancel"}} tabindex="6"></a>
-    <a href class='toggler fa {{togglerIcon}}' {{action "toggle" bubbles=false}} title={{i18n 'composer.toggler'}}></a>
-    <a href class='topic-link fa fa-external-link' {{action "openTopic"}} title={{i18n 'composer.open_message_topic'}}></a>
+    <a href class='cancel' {{action "cancel"}} tabindex="6">
+      {{d-icon 'times'}}
+    </a>
+    <a href class='toggler' {{action "toggle" bubbles=false}} title={{i18n 'composer.toggler'}}>
+      {{d-icon togglerIcon}}
+    </a>
+    <a href class='topic-link' {{action "openTopic"}} title={{i18n 'composer.open_message_topic'}}>
+      {{d-icon 'external-link'}}
+    </a>
   </div>
   {{#if firstPost}}
     {{user-selector topicId=topic.id
@@ -25,7 +31,9 @@
     {{#if showUsernames}}
       <div class="extra-usernames">
         {{otherUsernames}}
-        <a href class='cancel fa fa-times' {{action "showUsernames"}}></a>
+        <a href class='cancel' {{action "showUsernames"}}>
+          {{d-icon 'times'}}
+        </a>
       </div>
     {{/if}}
   {{/if}}

--- a/assets/javascripts/discourse/templates/components/docked-editor.hbs
+++ b/assets/javascripts/discourse/templates/components/docked-editor.hbs
@@ -1,6 +1,6 @@
 <div class='docked-editor-container'>
   <div class='button-bar'>
-    {{d-button action='openEmojiPicker' class='btn' icon='smile-o' mouseDown=(action 'buttonMousedown')}}
+    {{d-button action='openEmojiPicker' class='btn qm-emoji' icon='smile-o' mouseDown=(action 'buttonMousedown')}}
     {{docked-upload uploadDone=(action 'uploadDone') mouseDown=(action 'buttonMousedown')}}
   </div>
   <div class="docked-editor-textarea-wrapper">

--- a/assets/javascripts/discourse/templates/components/docked-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/docked-upload.hbs
@@ -4,7 +4,7 @@
   </div>
 {{else}}
   <label class="btn btn-small" disabled={{uploading}}>
-    {{d-icon "picture-o"}}
+    {{d-icon "picture-o" class='qm-upload-picture'}}
     <input disabled={{uploading}} type="file" style="visibility: hidden; position: absolute;" multiple/>
   </label>
 {{/if}}

--- a/assets/stylesheets/common/quick_menu.scss
+++ b/assets/stylesheets/common/quick_menu.scss
@@ -105,6 +105,7 @@
   }
 
   .is-warning {
+    // TODO: replace this with an icon in DOM, Discourse no longer supports FA4.7 font icons
     i.fa-envelope-o {
       &:before {
         content: "\f0e0";
@@ -151,6 +152,13 @@
         font-size: 17px;
         display: initial;
         padding: 5px;
+      }
+
+      svg.d-icon {
+        width: 24px;
+        margin-right: 5px;
+        vertical-align: middle;
+        display: inline-block;
       }
     }
   }

--- a/assets/stylesheets/common/quick_menu.scss
+++ b/assets/stylesheets/common/quick_menu.scss
@@ -104,17 +104,6 @@
     color: dark-light-choose(scale-color($primary, $lightness: 30%), scale-color($secondary, $lightness: 70%));
   }
 
-  .is-warning {
-    // TODO: replace this with an icon in DOM, Discourse no longer supports FA4.7 font icons
-    i.fa-envelope-o {
-      &:before {
-        content: "\f0e0";
-      }
-
-      color: $danger;
-    }
-  }
-
   .read {
     background-color: $secondary;
   }

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,6 +8,13 @@ register_asset 'stylesheets/common/quick_composer.scss'
 register_asset 'stylesheets/mobile/quick_mobile.scss', :mobile
 require_relative 'lib/setting_quick_messages_badge'
 
+if respond_to?(:register_svg_icon)
+  register_svg_icon "angle-up"
+  register_svg_icon "angle-down"
+  register_svg_icon "external-link"
+  register_svg_icon "times"
+end
+
 after_initialize do
 
   Post.register_custom_field_type('quick_message', :boolean)


### PR DESCRIPTION
This should solve any issues with missing icons when Discourse core updates to FA5. See https://meta.discourse.org/t/introducing-font-awesome-5-and-svg-icons/101643 for details. 

Note that there is one icon override in the CSS pseudo element that this PR does NOT fix. 