### PR TITLE
DEV: Use UppyUploadMixin for docked-upload

### DIFF
--- a/assets/javascripts/discourse/components/docked-editor.js.es6
+++ b/assets/javascripts/discourse/components/docked-editor.js.es6
@@ -15,6 +15,9 @@ export default DEditor.extend({
     const $element = $(this.element);
     const $editorInput = $element.find('.d-editor-input');
     this._applyMentionAutocomplete($editorInput);
+    this._textarea = this.element.querySelector("textarea.d-editor-input");
+    this._$textarea = $(this._textarea);
+    this.set("ready", true);
   },
 
   _applyMentionAutocomplete($editorInput) {

--- a/assets/javascripts/discourse/components/docked-upload.js.es6
+++ b/assets/javascripts/discourse/components/docked-upload.js.es6
@@ -1,19 +1,22 @@
 import UploadMixin from "discourse/mixins/upload";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import Component from "@ember/component";
 
-export default Component.extend(UploadMixin, {
-  tagName: 'button',
-  classNames: 'docked-upload btn btn-small',
-  attributeBindings: ['uploading:disabled'],
-  type: 'PUT',
+export default Component.extend(UppyUploadMixin, {
+  id: "docked-upload",
+  tagName: "button",
+  type: "quick_message_upload",
+  classNames: "docked-upload btn btn-small",
+  attributeBindings: ["uploading:disabled"],
+  fileInputSelector: ".docked-upload-file-input",
 
   input() {
-    return $(this.element).find('input');
+    return $(this.element).find("input");
   },
 
   click(e) {
-    if (!$(e.target).is('input')) {
-      this.input().trigger('click');
+    if (!$(e.target).is("input")) {
+      this.input().trigger("click");
     }
-  }
+  },
 });

--- a/assets/javascripts/discourse/templates/components/docked-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/docked-upload.hbs
@@ -4,5 +4,5 @@
   </div>
 {{else}}
   {{d-icon "far-image" class='qm-upload-picture'}}
-  <input disabled={{uploading}} type="file" multiple/>
+  <input class="docked-upload-file-input" disabled={{uploading}} type="file" multiple/>
 {{/if}}

--- a/assets/javascripts/discourse/widgets/docked-post.js.es6
+++ b/assets/javascripts/discourse/widgets/docked-post.js.es6
@@ -8,7 +8,10 @@ class QuickPostCooked extends PostCooked {
     const $html = $(`<div class='cooked'>${this.attrs.cooked}</div>`);
     this._insertQuoteControls($html);
     this._showLinkCounts($html);
-    this._fixImageSizes($html);
+
+    // removed inhttps://github.com/discourse/discourse/commit/e305365168528883872d4ce9efd109e41149ef0a
+    // this._fixImageSizes($html);
+
     this._applySearchHighlight($html);
     return $html[0];
   }


### PR DESCRIPTION
This commit changes the docked-upload to use the new UppyUploadMixin
from discourse core; the old mixin is no longer supported.

I also added some minor fixes around changed APIs for the docked-editor
which inherits from d-editor and implements textarea-text-manipulation,
without this fix the upload text would not be added.