### PR TITLE
DEV: Fix `triggerNewPostInStream` deprecation

### DIFF
--- a/assets/javascripts/discourse/components/docked-composer.js.es6
+++ b/assets/javascripts/discourse/components/docked-composer.js.es6
@@ -416,7 +416,7 @@ export default Component.extend({
 
     this.messageBus.subscribe("/topic/" + topic.id, data => {
       if (data.type === "created") {
-        postStream.triggerNewPostInStream(data.id).then(() => this.afterStreamRender());
+        postStream.triggerNewPostsInStream([data.id]).then(() => this.afterStreamRender());
         if (this.get('currentUser.id') !== data.user_id) {
           Discourse.incrementBackgroundContextCount();
         }


### PR DESCRIPTION
It was replaced by `triggerNewPostsInStream` in https://github.com/discourse/discourse/pull/10888